### PR TITLE
[FIX] Add K8s provider

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -36,3 +36,11 @@ data "aws_eks_cluster" "cluster" {
 data "aws_eks_cluster_auth" "cluster" {
   name = module.eks.cluster_id
 }
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+  version                = "~> 1.9"
+}


### PR DESCRIPTION
When `terraform apply` was run, it failed with the same error in this issue: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/659

This fix makes `terraform apply` complete successfully.

Tested with versions below.

```
> terraform --version
Terraform v0.12.24
+ provider.aws v2.58.0
+ provider.kubernetes v1.11.1
+ provider.local v1.4.0
+ provider.null v2.1.2
+ provider.random v2.2.1
+ provider.template v2.1.2
```