### PR TITLE
Specify required cluster_version

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -1,7 +1,8 @@
 module "eks" {
-  source       = "terraform-aws-modules/eks/aws"
-  cluster_name = local.cluster_name
-  subnets      = module.vpc.private_subnets
+  source          = "terraform-aws-modules/eks/aws"
+  cluster_name    = local.cluster_name
+  cluster_version = "1.17"
+  subnets         = module.vpc.private_subnets
 
   tags = {
     Environment = "training"


### PR DESCRIPTION
This must have been a recent addition to the module because it was not previously required but now fails without it.