### PR TITLE
Align readme file with content from tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The following command will get the access credentials for your cluster and autom
 configure `kubectl`.
 
 ```shell
-$ aws eks --region us-east-2 update-kubeconfig --name training-eks-sR8eLIil
+$ aws eks --region $(terraform output region) update-kubeconfig --name $(terraform output cluster_name)
 ```
 
 The


### PR DESCRIPTION
I was a bit confused that the cluster names didn't align. The sample code from the tutorial itself utilizes the `terraform output` command to extract the real cluster name such that the same command would work as-is.

This PR aligns the readme in this repo to the content on the tutorial with regard to configuring `kubectl` after provisioning the cluster.