### PR TITLE
feat: update kubernetes version

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -1,7 +1,7 @@
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
   cluster_name    = local.cluster_name
-  cluster_version = "1.17"
+  cluster_version = "1.18"
   subnets         = module.vpc.private_subnets
 
   tags = {


### PR DESCRIPTION
# Description

Update kubernetes version to the latest stable version (1.18)
Reference: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.18

# Motivation and context

Upgrade to the latest Kubernetes version available in AWS EKS following the AWS best practises.
This update to 1.18 also avoids the information message displayed in AWS console asking you to upgrade the cluster to 1.18.

# Types of changes

- eks-cluster.tf ( cluster_version )
