### PR TITLE
Fix it to work after terraform-aws-modules/eks/aws 18 release

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -1,5 +1,6 @@
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
+  version         = "17.24.0"
   cluster_name    = local.cluster_name
   cluster_version = "1.20"
   subnets         = module.vpc.private_subnets


### PR DESCRIPTION
The example doesn't work because terraform-aws-modules/eks/aws released v18 version. The new version isn't backwards compatible with v17 and actually requires a bit of rewrite in TF files. I added a single-line fix to force the example to use v17 module. 